### PR TITLE
Add default Windows apps removal and rollback options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The following configurations can be updated within the script. Your team should 
 * <ins>SMB Configuration</ins>: This setting controls the configuration settings for SMB. Disabling will turn off SMB server and Workstation shares and will turn on and require SMB signing and encryption. Rolling back will reset the system to normal SMB default configuration which is to turn on SMB server and Workstation shares and disable SMB signing and encryption.
 * <ins>SMBv1</ins>: This setting controls the use of SMBv1. Disabling will disable SMBv1 on the system. ***Rolling back does nothing.*** You don't need SMBv1 for a stand-alone system. Don't enable it. Fire your vendor or integrator if they force you to enable it. If you really need it, you'll figure out how to enable it.
   * Seriously, you don't need SMBv1. Disabling it is extremely important.
+* <ins>Default Windows Apps</ins>: By default Windows 10 installs tens of additional applications not needed for ICS environment on the first user log in, such as BingWeather or XboxGameOverlay.  Some of them are described on the [Mircrosoft website](https://docs.microsoft.com/en-us/windows/application-management/apps-in-windows-10). Disabling will uninstall most of the default Windows Apps. Rolling back will install them again (without recreating menu start tiles and windows bar shortcuts). The apps list can be modified per needs in the code.
 
 ## Considerations
 Check is safe. It makes no changes and there is a separate confirmation prompt when changes will be made to the system.

--- a/sawh.ps1
+++ b/sawh.ps1
@@ -546,14 +546,14 @@ function Set-SMBv1State(){
 
 # Default Windows apps
 ####################
-function Get-InstalledWindowsApps(){
+function Get-DefaultWindowsApps(){
 	Write-Host '[*] Getting list of installed Windows apps'
     Get-AppxPackage | Format-Table Name
     # Uncomment to get list of apps that will be installed for future users
 	#Get-AppxProvisionedPackage -Online | Format-Table DisplayName, PackageName
 }
 
-function Set-InstalledWindowsApps(){
+function Set-DefaultWindowsApps(){
 	Param(
 		# Enable means to change the setting to the default / insecure state.
 		$Enable = $false
@@ -683,7 +683,7 @@ function Write-SystemState {
 	Get-TerminalServicesState
 	Get-SMBConfigState
 	Get-SMBv1State
-	Get-InstalledWindowsApps
+	Get-DefaultWindowsApps
 }
 ####################
 
@@ -740,7 +740,7 @@ if ($disable){
 	Set-TerminalServicesState
 	Set-SMBConfigState
 	Set-SMBv1State
-	Set-InstalledWindowsApps
+	Set-DefaultWindowsApps
 }
 
 # Run rollback function
@@ -757,7 +757,7 @@ if ($rollback){
 	Set-TerminalServicesState -Enable $true
 	Set-SMBConfigState -Enable $true 
 	Set-SMBv1State -Enable $true
-	Set-InstalledWindowsApps -Enable $true
+	Set-DefaultWindowsApps -Enable $true
 
 }
 

--- a/sawh.ps1
+++ b/sawh.ps1
@@ -62,7 +62,7 @@ $start_state     = $true       # Enable / disable writing the system's state bef
 $completed_state = $true       # Enable / disable writing the system's state after changes
 
 # Global Configuration verbs, modify these to disable modifications
-$inf_private_mode = $true # Network interfaces mode - true: Public' mode, false: 'Private' mode
+$inf_private_mode = $true # Network interfaces mode - true: 'Private' mode, false: 'Public' mode
 $disable_netbios  = $true # Disable NetBIOS for all network interfaces
 $fw_rules         = $true # Apply SAWH firewall rules
 $inf_bindings     = $true # Change configuration of network interfaces 

--- a/sawh.ps1
+++ b/sawh.ps1
@@ -289,7 +289,7 @@ function Set-SAWHFWRulesState(){
 
 # Interface inf_bindings
 ####################
-function Get-Netinf_bindingsState(){
+function Get-NetInfBindingsState(){
 	####################
 	# Check Network Adapter inf_bindings
 	####################
@@ -300,7 +300,7 @@ function Get-Netinf_bindingsState(){
 	Write-Host ''
 }
 
-function Set-Netinf_bindingsState(){
+function Set-NetInfBindingsState(){
 	
 	Param(
 		# Enable means to change the setting to the default / insecure state.
@@ -597,7 +597,7 @@ function Write-SystemState {
 	Get-InterfaceModeState
 	Get-NetBIOSState
 	Get-SAWHFWRulesState
-	Get-Netinf_bindingsState
+	Get-NetInfBindingsState
 	Get-TerminalServicesState
 	Get-SMBConfigState
 	Get-SMBv1State
@@ -653,7 +653,7 @@ if ($disable){
 	Set-InterfaceModeState
 	Set-NetBIOSState
 	Set-SAWHFWRulesState
-	Set-Netinf_bindingsState
+	Set-NetInfBindingsState
 	Set-TerminalServicesState
 	Set-SMBConfigState
 	Set-SMBv1State
@@ -669,7 +669,7 @@ if ($rollback){
 	Set-InterfaceModeState -Enable $true
 	Set-NetBIOSState -Enable $true
 	Set-SAWHFWRulesState -Enable $true
-	Set-Netinf_bindingsState -Enable $true
+	Set-NetInfBindingsState -Enable $true
 	Set-TerminalServicesState -Enable $true
 	Set-SMBConfigState -Enable $true 
 	Set-SMBv1State -Enable $true


### PR DESCRIPTION
By default Windows 10 installs tens of additional applications not needed for ICS environment on the first user log in, such as BingWeather or XboxGameOverlay. This PR adds code to remove them and rollback as needed.